### PR TITLE
Replace all instances of PYTHON_USEDEP with PYTHON_SINGLE_USE_DEP

### DIFF
--- a/sys-power/throttled/throttled-0.5.ebuild
+++ b/sys-power/throttled/throttled-0.5.ebuild
@@ -19,8 +19,8 @@ IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
-	dev-python/dbus-python[${PYTHON_USEDEP}]
-	dev-python/pygobject[${PYTHON_USEDEP}]
+	dev-python/dbus-python[${PYTHON_SINGLE_USEDEP}]
+	dev-python/pygobject[${PYTHON_SINGLE_USEDEP}]
 "
 DEPEND="${PYTHON_DEPS}"
 

--- a/sys-power/throttled/throttled-0.6.ebuild
+++ b/sys-power/throttled/throttled-0.6.ebuild
@@ -19,8 +19,8 @@ IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
-	dev-python/dbus-python[${PYTHON_USEDEP}]
-	dev-python/pygobject[${PYTHON_USEDEP}]
+	dev-python/dbus-python[${PYTHON_SINGLE_USEDEP}]
+	dev-python/pygobject[${PYTHON_SINGLE_USEDEP}]
 "
 DEPEND="${PYTHON_DEPS}"
 

--- a/sys-power/throttled/throttled-9999.ebuild
+++ b/sys-power/throttled/throttled-9999.ebuild
@@ -18,8 +18,8 @@ IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
-	dev-python/dbus-python[${PYTHON_USEDEP}]
-	dev-python/pygobject[${PYTHON_USEDEP}]
+	dev-python/dbus-python[${PYTHON_SINGLE_USEDEP}]
+	dev-python/pygobject[${PYTHON_SINGLE_USEDEP}]
 "
 DEPEND="${PYTHON_DEPS}"
 


### PR DESCRIPTION
@erpalma 

On February 10, 2020 Michał Górny, one of the Gentoo Developers, announced some fundamental changes to python-single-r1.eclass. 

To make a long story short,
1. `PYTHON_TARGETS` will be disappearing from single-r1 packages.
2. `PYTHON_SINGLE_TARGET` will only be necessary in single-r1 packages.
3. `PYTHON_USEDEP` is no longer valid in single-r1 packages.
4. `PYTHON_SINGLE_USEDEP` replaces `PYTHON_USEDEP` for dependencies on other single-r1 packages and is a global variable.
5. `PYTHON_MULTI_USEDEP` replaces `PYTHON_USEDEP` for multi-impl packages and is only available as a placeholder in `python_gen_cond_dep`.

**To enforce these changes, the eclass will fail when this logic is used.** In particular, the eclass will fail producing the following error for all the ebuilds in this overlay:
```shell
!!! All ebuilds that could satisfy "throttled" have been masked.
!!! One of the following masked packages is required to complete your request:
- sys-power/throttled-9999::throttled (masked by: invalid: RDEPEND: Invalid atom (Invalid use dep: '%PYTHON_USEDEP-HAS-BEEN-REMOVED%'), token 6)
- sys-power/throttled-0.6::throttled (masked by: invalid: RDEPEND: Invalid atom (Invalid use dep: '%PYTHON_USEDEP-HAS-BEEN-REMOVED%'), token 6)
- sys-power/throttled-0.5::throttled (masked by: invalid: RDEPEND: Invalid atom (Invalid use dep: '%PYTHON_USEDEP-HAS-BEEN-REMOVED%'), token 6)
```
As a consequence, users will not be able to emerge any of the builds in this overlay.

Offending ebuilds can be converted as follows:
1. Replace all `${PYTHON_USEDEP}`s with `${PYTHON_SINGLE_USEDEP}` when the dep is single-r1, or with `${PYTHON_MULTI_USEDEP}` otherwise.
2. Wrap all dependencies containing `${PYTHON_MULTI_USEDEP}` in a `python_gen_cond_dep` (the variable must be a literal placeholder, i.e. use single quotes).

My pull request makes the necessary changes in accordance with the guidelines outlined above.

More information about these changes can be found in the February 10, 2020 listing by Michał Górny titled [No more PYTHON_TARGETS in single-r1](https://planet.gentoo.org/universe/).