### PR TITLE
update ebuilds to support gentoo default python 3.11

### DIFF
--- a/sys-power/throttled/throttled-0.9.2.ebuild
+++ b/sys-power/throttled/throttled-0.9.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8,9,10} )
+PYTHON_COMPAT=( python3_{8,9,10,11} )
 
 inherit python-r1 linux-info systemd
 

--- a/sys-power/throttled/throttled-9999.ebuild
+++ b/sys-power/throttled/throttled-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8,9,10} )
+PYTHON_COMPAT=( python3_{8,9,10,11} )
 
 inherit python-r1 linux-info systemd
 


### PR DESCRIPTION
Gentoo moved to python 3.11 on may 1:st, this just adds 3.11 to the compat list. I've been running `-9999` on py311 for ~2 weeks and it seems fine